### PR TITLE
Add Basic Windows Support

### DIFF
--- a/lib/sipper/cli.ex
+++ b/lib/sipper/cli.ex
@@ -24,7 +24,7 @@ defmodule Sipper.CLI do
 
     config = %Sipper.Config{
       auth: {user, pw},
-      dir: Dict.get(options, :dir, "./downloads"),
+      dir: Dict.get(options, :dir, "./downloads") |> Path.expand ,
       max: Dict.get(options, :max, :unlimited),
     }
 

--- a/lib/sipper/feed_cache.ex
+++ b/lib/sipper/feed_cache.ex
@@ -1,5 +1,5 @@
 defmodule Sipper.FeedCache do
-  @path "/tmp/sipper.cache"
+  @path System.tmp_dir() <> "/sipper.cache"
   @ttl_seconds 60 * 10
 
   def read do

--- a/lib/sipper/runner.ex
+++ b/lib/sipper/runner.ex
@@ -38,7 +38,7 @@ defmodule Sipper.Runner do
   end
 
   defp download_file(title, {id, name}, config) do
-    dir = "#{config.dir}/#{title}"
+    dir = "#{config.dir}/#{title |> String.replace(":", " ")}"
     File.mkdir_p!(dir)
 
     path = "#{dir}/#{name}"


### PR DESCRIPTION
Sipper was broken on windows. The issues revolved around path management. 

This pull request adds very basic support that gets sipper downloading files correctly. 

Still to fix: 
- The progress bar implementation is not working well in windows. It is not clearing the current line. 
