### PR TITLE
Add new option to download episodes from the earliest to the newest releases.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ erl_crash.dump
 
 # Downloaded files
 /downloads
+mix.lock

--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ If you want to limit the download to e.g. the last 3 episodes, do:
 
     ./sipper --user me@example.com --pw mypassword --max 3
 
+You may also want start downloading from very beginning. To do so:
+
+     ./sipper --user me@example.com --pw mypassword --oldest-first
+
 By default, files end up in `./downloads`. You can specify another destination (automatically created if it doesn't exist):
 
     ./sipper --user me@example.com --pw mypassword --dir ~/Downloads/Elixir\ Sips
@@ -47,6 +51,13 @@ If you don't want to specify these parameters each time, you can put them in a `
 Then you can just run the app like:
 
     ./sipper
+
+Assuming you've created `~/.sipper` file with the configuration above, you may also pass more command-line args:
+
+    ./sipper --oldest-first --max 3 --dir ~/Videos/Elixir\ Sips
+
+So, even if you had `--dir ~/Downloads/Elixir\ Sips` in your `~/.sipper` file, the `--dir ~/Videos/Elixir\ Sips` arguments will have
+preference over it.
 
 
 ## Don't be evil

--- a/lib/sipper/cli.ex
+++ b/lib/sipper/cli.ex
@@ -1,17 +1,18 @@
 defmodule Sipper.CLI do
   @config_file System.user_home! <> "/.sipper"
 
-  def main([]) do
-    if File.exists?(@config_file) do
-      args = File.read!(@config_file) |> String.rstrip |> OptionParser.split
-      main(args)
-    else
-      IO.puts :stderr, "Please provide parameters!"
-    end
+  def main(args) do
+    parse_config_file ++ args
+    |> parse_args
+    |> run
   end
 
-  def main(args) do
-    args |> parse_args |> run
+  defp parse_config_file() do
+    args = []
+    if File.exists?(@config_file) do
+      args = File.read!(@config_file) |> String.rstrip |> OptionParser.split
+    end
+    args
   end
 
   defp parse_args(args) do
@@ -23,6 +24,7 @@ defmodule Sipper.CLI do
       switches: [
         max: :integer,
         dir: :string,
+        oldest_first: :boolean,
       ],
     )
 
@@ -30,6 +32,7 @@ defmodule Sipper.CLI do
   end
 
   defp run(options) do
+
     user = Dict.fetch!(options, :user)
     pw = Dict.fetch!(options, :pw)
 
@@ -37,7 +40,10 @@ defmodule Sipper.CLI do
       auth: {user, pw},
       dir: Dict.get(options, :dir, "./downloads") |> Path.expand,
       max: Dict.get(options, :max, :unlimited),
+      oldest_first: Dict.get(options, :oldest_first, :false),
     }
+
+    IO.inspect config
 
     Sipper.Runner.run(config)
   end

--- a/lib/sipper/config.ex
+++ b/lib/sipper/config.ex
@@ -1,3 +1,3 @@
 defmodule Sipper.Config do
-  defstruct auth: nil, dir: nil, max: nil
+  defstruct auth: nil, dir: nil, max: nil, oldest_first: nil
 end

--- a/lib/sipper/runner.ex
+++ b/lib/sipper/runner.ex
@@ -2,6 +2,7 @@ defmodule Sipper.Runner do
   def run(config) do
     get_feed(config)
     |> parse_feed
+    |> order_by_oldest(config.oldest_first)
     |> limit_to(config.max)
     |> download(config)
   end
@@ -13,6 +14,9 @@ defmodule Sipper.Runner do
   defp parse_feed(feed) do
     Sipper.FeedParser.parse(feed)
   end
+
+  defp order_by_oldest(episodes, :false), do: episodes
+  defp order_by_oldest(episodes, :true), do: episodes |> Enum.reverse
 
   defp limit_to(episodes, :unlimited), do: episodes
   defp limit_to(episodes, max), do: episodes |> Enum.take(max)

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,0 @@
-%{"floki": {:hex, :floki, "0.4.1"},
-  "httpotion": {:hex, :httpotion, "2.1.0"},
-  "ibrowse": {:git, "git://github.com/cmullaparthi/ibrowse.git", "ea3305d21f37eced4fac290f64b068e56df7de80", [tag: "v4.1.2"]},
-  "mochiweb": {:hex, :mochiweb, "2.12.2"},
-  "poolboy": {:git, "git://github.com/devinus/poolboy.git", "3bb48a893ff5598f7c73731ac17545206d259fac", []},
-  "progress_bar": {:hex, :progress_bar, "1.3.0"}}


### PR DESCRIPTION
1. Implement --oldest-first, so that Sipper will download the episode in reverse, from the oldest to the newest ones.
2. Make Sipper work with both the sipper config file and the command-line arguments at the same time. The arguments will have preference over the ones inside the config file.
